### PR TITLE
Create DoDonPachi (Japan, no warn).mra

### DIFF
--- a/mra/DoDonPachi (Japan, no warn).mra
+++ b/mra/DoDonPachi (Japan, no warn).mra
@@ -1,0 +1,52 @@
+<misterromdescription>
+  <name>DoDonPachi (Japan, Master Ver. 970205)</name>
+  <mameversion>0226</mameversion>
+  <setname>ddonpach</setname>
+  <mratimestamp>20210102</mratimestamp>
+  <year>1997</year>
+  <manufacturer>CAVE</manufacturer>
+  <category>Shooter</category>
+  <rbf>cave</rbf>
+
+  <buttons names="Shots/Laser,Spread/Laser Bomber,Full-Auto,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+
+  <!-- select game -->
+  <rom index="1">
+    <part>1</part>
+  </rom>
+
+  <!-- ROM data -->
+  <rom index="0" zip="ddonpach.zip|ddonpachj.zip" md5="f7ea580bd89e789712cb1524e808d9b1">
+    <!-- main CPU -->
+    <interleave output="16">
+      <part name="u27.bin" crc="2432ff9b" map="10" />
+      <part name="u26.bin" crc="4f3a914a" map="01" />
+    </interleave>
+
+    <!-- sprites -->
+    <part name="u50.bin" crc="14b260ec" />
+    <part name="u51.bin" crc="e7ba8cce" />
+    <part name="u52.bin" crc="02492ee0" />
+    <part name="u53.bin" crc="cb4c10f0" />
+
+    <!-- layer 0 -->
+    <part name="u60.bin" crc="903096a7" />
+
+    <!-- layer 1 -->
+    <part name="u61.bin" crc="d89b7631" />
+
+    <!-- layer 2 -->
+    <part name="u62.bin" crc="292bfb6b" />
+
+    <!-- samples -->
+    <part name="u6.bin" crc="9dfdafaf" />
+    <part name="u7.bin" crc="795b17d5" />
+
+    <!-- skip CRC -->
+    <patch offset="0x005410">00 60 0C 00</patch>
+    <!-- skip warning -->
+    <patch offset="0x0054EC">00 60 50 00</patch>
+    <!-- enable C-button -->
+    <patch offset="0x0067AC">71 4E</patch>
+  </rom>
+</misterromdescription>


### PR DESCRIPTION
MRA for the Japanese version of DoDonPachi with patches for skipping the CRC check, skipping the copyright warning screen, and adding the C-button for 'Full-Auto'.