### PR TITLE
Fix breaking burst transaction on reset

### DIFF
--- a/quartus/cave.sv
+++ b/quartus/cave.sv
@@ -229,6 +229,32 @@ reset_ctrl reset_cpu_ctrl (
   .rst_o(rst_cpu)
 );
 
+f2sdram_safe_terminator f2sdram_safe_terminator (
+  .clk(clk_sys),
+  .rst_req_sync(rst_sys),
+
+  .waitrequest_master(DDRAM_BUSY),
+  .burstcount_master(DDRAM_BURSTCNT),
+  .address_master(DDRAM_ADDR),
+  .readdata_master(DDRAM_DOUT),
+  .readdatavalid_master(DDRAM_DOUT_READY),
+  .read_master(DDRAM_RD),
+  .writedata_master(DDRAM_DIN),
+  .byteenable_master(DDRAM_BE),
+  .write_master(DDRAM_WE),
+
+  .waitrequest_slave(CORE_DDRAM_BUSY),
+  .burstcount_slave(CORE_DDRAM_BURSTCNT),
+  .address_slave(CORE_DDRAM_ADDR),
+  .readdata_slave(CORE_DDRAM_DOUT),
+  .readdatavalid_slave(CORE_DDRAM_DOUT_READY),
+  .read_slave(CORE_DDRAM_RD),
+  .writedata_slave(CORE_DDRAM_DIN),
+  .byteenable_slave(CORE_DDRAM_BE),
+  .write_slave(CORE_DDRAM_WE)
+);
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // HPS IO
 ////////////////////////////////////////////////////////////////////////////////
@@ -412,9 +438,19 @@ wire        sdram_oe;
 wire [15:0] sdram_din;
 wire [15:0] sdram_dout;
 
-assign DDRAM_ADDR = ddr_addr[31:3];
+wire DDRAM_ADDR_CORE = ddr_addr[31:3];
 assign SDRAM_DQ = sdram_oe ? sdram_din : 16'bZ;
 assign sdram_dout = SDRAM_DQ;
+
+wire         CORE_DDRAM_BUSY;
+wire   [7:0] CORE_DDRAM_BURSTCNT;
+wire  [28:0] CORE_DDRAM_ADDR = ddr_addr[31:3];
+wire  [63:0] CORE_DDRAM_DOUT;
+wire         CORE_DDRAM_DOUT_READY;
+wire         CORE_DDRAM_RD;
+wire  [63:0] CORE_DDRAM_DIN;
+wire   [7:0] CORE_DDRAM_BE;
+wire         CORE_DDRAM_WE;
 
 Main main (
   // Fast clock domain
@@ -475,15 +511,15 @@ Main main (
   .io_frameBuffer_lowLat(FB_LL),
   .io_frameBuffer_forceBlank(FB_FORCE_BLANK),
   // DDR
-  .io_ddr_rd(DDRAM_RD),
-  .io_ddr_wr(DDRAM_WE),
+  .io_ddr_rd(CORE_DDRAM_RD),
+  .io_ddr_wr(CORE_DDRAM_WE),
   .io_ddr_addr(ddr_addr),
-  .io_ddr_mask(DDRAM_BE),
-  .io_ddr_din(DDRAM_DIN),
-  .io_ddr_dout(DDRAM_DOUT),
-  .io_ddr_waitReq(DDRAM_BUSY),
-  .io_ddr_valid(DDRAM_DOUT_READY),
-  .io_ddr_burstLength(DDRAM_BURSTCNT),
+  .io_ddr_mask(CORE_DDRAM_BE),
+  .io_ddr_din(CORE_DDRAM_DIN),
+  .io_ddr_dout(CORE_DDRAM_DOUT),
+  .io_ddr_waitReq(CORE_DDRAM_BUSY),
+  .io_ddr_valid(CORE_DDRAM_DOUT_READY),
+  .io_ddr_burstLength(CORE_DDRAM_BURSTCNT),
   // SDRAM
   .io_sdram_cke(SDRAM_CKE),
   .io_sdram_cs_n(SDRAM_nCS),

--- a/quartus/files.qip
+++ b/quartus/files.qip
@@ -10,6 +10,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE cave.sv
 set_global_assignment -name VERILOG_FILE rtl/ChiselTop.v
 set_global_assignment -name VERILOG_FILE rtl/jteeprom/hdl/jt9346.v
 set_global_assignment -name VERILOG_FILE rtl/reset_ctrl.v
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/f2sdram_safe_terminator.sv
 set_global_assignment -name VHDL_FILE rtl/mem/dual_port_ram.vhd
 set_global_assignment -name VHDL_FILE rtl/mem/single_port_ram.vhd
 set_global_assignment -name VHDL_FILE rtl/mem/true_dual_port_ram.vhd

--- a/quartus/rtl/f2sdram_safe_terminator.sv
+++ b/quartus/rtl/f2sdram_safe_terminator.sv
@@ -1,0 +1,251 @@
+// ============================================================================
+//
+//                f2sdram_safe_terminator for MiSTer platform
+//
+// ============================================================================
+// Copyright (c) 2021 bellwood420
+//
+// Background:
+//
+//   Terminating a transaction of burst writing(/reading) in its midstream
+//   seems to cause an illegal state to f2sdram interface.
+//
+//   Forced reset request that occurs when loading other core is inevitable.
+//
+//   So if it happens exactly within the transaction period,
+//   unexpected issues with accessing to f2sdram interface will be caused
+//   in next loaded core.
+//
+//   It seems that only way to reset broken f2sdram interface is to reset
+//   whole SDRAM Controller Subsystem from HPS via permodrst register
+//   in Reset Manager.
+//   But it cannot be done safely while Linux is running.
+//   It is usually done when cold or warm reset is issued in HPS.
+//
+//   Main_MiSTer is issuing reset for FPGA <> HPS bridges
+//   via brgmodrst register in Reset Manager when loading rbf.
+//   But it has no effect on f2sdram interface.
+//   f2sdram interface seems to belong to SDRAM Controller Subsystem
+//   rather than FPGA-to-HPS bridge.
+//
+//   Main_MiSTer is also trying to issuing reset for f2sdram ports
+//   via fpgaportrst register in SDRAM Controller Subsystem when loading rbf.
+//   But according to the Intel's document, fpgaportrst register can be
+//   used to strech the port reset.
+//   It seems that it cannot be used to assert the port reset.
+//
+//   According to the Intel's document, there seems to be a reset port on
+//   Avalon-MM slave interface, but it cannot be found in Qsys generated HDL.
+//
+//   To conclude, the only thing FPGA can do is not to break the transaction.
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//
+// Purpose:
+//   To prevent the issue, this module completes ongoing transaction
+//   on behalf of user logic, when reset is asserted.
+//
+// Usage:
+//   Insert this module into the bus line between
+//   f2sdram (Avalon-MM slave) and user logic (Avalon-MM master).
+//
+// Notice:
+//   Asynchronous reset request is not supported.
+//   Please feed reset request synchronized to clock.
+//
+module f2sdram_safe_terminator #(
+  parameter     ADDRESS_WITDH = 29,
+  parameter     DATA_WIDTH = 64,
+  parameter     BURSTCOUNT_WIDTH = 8,
+  parameter     BYTEENABLE_WIDTH = 8
+) (
+  // clk should be the same as one provided to f2sdram port
+  input         clk,
+  // rst_req_sync should be synchronized to clk
+  // Asynchronous reset request is not supported
+  input         rst_req_sync,
+
+  // Master port: connecting to Alavon-MM slave(f2sdram)
+  input                         waitrequest_master,
+  output [BURSTCOUNT_WIDTH-1:0] burstcount_master,
+  output    [ADDRESS_WITDH-1:0] address_master,
+  input        [DATA_WIDTH-1:0] readdata_master,
+  input                         readdatavalid_master,
+  output                        read_master,
+  output       [DATA_WIDTH-1:0] writedata_master,
+  output [BYTEENABLE_WIDTH-1:0] byteenable_master,
+  output                        write_master,
+
+  // Slave port: connecting to Alavon-MM master(user logic)
+  output                        waitrequest_slave,
+  input  [BURSTCOUNT_WIDTH-1:0] burstcount_slave,
+  input     [ADDRESS_WITDH-1:0] address_slave,
+  output       [DATA_WIDTH-1:0] readdata_slave,
+  output                        readdatavalid_slave,
+  input                         read_slave,
+  input        [DATA_WIDTH-1:0] writedata_slave,
+  input  [BYTEENABLE_WIDTH-1:0] byteenable_slave,
+  input                         write_slave
+);
+  /*
+   * Burst transaction observer
+   */
+  typedef enum reg [1:0] {
+    IDLE, READ, WRITE
+  } state_t;
+
+  state_t state = IDLE;
+  state_t next_state;
+
+  wire burst_start = state == IDLE  && (next_state == READ || next_state == WRITE);
+  wire read_data   = state == READ  && readdatavalid_master;
+  wire write_data  = state == WRITE && !waitrequest_master;
+  wire burst_end   = (state == READ || state == WRITE) && burstcounter == burstcount_latch - 'd1;
+  wire successful_non_burst_write = state == IDLE && write_slave && burstcount_slave == 'd1 && !waitrequest_master; 
+
+  reg [BURSTCOUNT_WIDTH-1:0] burstcounter       = 'd0;
+  reg [BURSTCOUNT_WIDTH-1:0] burstcount_latch   = 'd0;
+  reg [ADDRESS_WITDH-1:0]    address_latch      = 'd0;
+  reg [BYTEENABLE_WIDTH-1:0] byteenable_latch   = 'd0;
+  reg read_latch  = 1'b0;
+  reg write_latch = 1'b0;
+
+  always_ff @(posedge clk) begin
+    state <= next_state;
+
+    if (burst_start) begin
+      if (next_state == WRITE) begin
+        burstcounter <= waitrequest_master ? 'd0 :'d1;
+      end else if (next_state == READ) begin
+        burstcounter <= 'd0;
+      end
+
+      burstcount_latch <= burstcount_slave;
+      byteenable_latch <= byteenable_slave;
+      address_latch    <= address_slave;
+      read_latch       <= next_state == READ;
+      write_latch      <= next_state == WRITE;
+
+    end else if (read_data || write_data) begin
+      burstcounter <= burstcounter + 'd1;
+
+    end else if (burst_end) begin
+      read_latch  <= 1'b0;
+      write_latch <= 1'b0;
+    end
+  end
+
+  always_comb begin
+    case (state)
+      IDLE:     if (successful_non_burst_write)
+                  next_state <= IDLE;
+                else if (read_slave)
+                  next_state <= READ;
+                else if (write_slave)
+                  next_state <= WRITE;
+                else
+                  next_state <= IDLE;
+
+      READ:     if (burst_end)
+                  next_state <= IDLE;
+                else
+                  next_state <= READ;
+
+      WRITE:    if (burst_end)
+                  next_state <= IDLE;
+                else
+                  next_state <= WRITE;
+
+      default:  next_state <= IDLE;
+    endcase
+  end
+
+  /*
+   * Safe terminating
+   */
+  wire on_transaction = (state == READ || state == WRITE) && (next_state != IDLE);
+  reg terminating = 1'b0;
+  reg terminated = 1'b0;
+
+  reg [BURSTCOUNT_WIDTH-1:0] terminate_counter = 'd0;
+  reg [BURSTCOUNT_WIDTH-1:0] terminate_count = 'd0;
+  reg [ADDRESS_WITDH-1:0]    terminate_address_latch      = 'd0;
+  reg [BYTEENABLE_WIDTH-1:0] terminate_byteenable_latch   = 'd0;
+  reg terminate_read_latch  = 1'b0;
+  reg terminate_write_latch = 1'b0;
+
+  reg init_reset_deasserted = 1'b0;
+
+  always_ff @(posedge clk) begin
+    if (rst_req_sync) begin
+      // Reset assert
+      if (init_reset_deasserted) begin
+        if (on_transaction) begin
+          terminating <= 1'b1;
+          terminate_counter          <= burstcounter + 'd1;
+          terminate_count            <= burstcount_latch;
+          terminate_address_latch    <= address_latch;
+          terminate_byteenable_latch <= byteenable_latch;
+          terminate_read_latch       <= read_latch;
+          terminate_write_latch      <= write_latch;
+        end else begin
+          terminated = 1'b1;
+        end
+      end
+    end else begin
+      // Reset deassert
+      if (!terminating) begin
+        terminated <= 1'b0;
+      end
+      init_reset_deasserted <= 1'b1;
+    end
+
+    if (terminating) begin
+      // Continue read/write transaction until the end
+
+      if (terminate_read_latch && readdatavalid_master) begin
+        terminate_counter <= terminate_counter + 'd1;
+      end else if (terminate_write_latch && !waitrequest_master) begin
+        terminate_counter <= terminate_counter + 'd1;
+      end
+
+      if (terminate_counter == terminate_count - 'd1) begin
+        terminating <= 1'b0;
+        terminated <= 1'b1;
+      end
+    end
+  end
+
+  /*
+   * Bus mux depending on the stage.
+   */
+  always_comb begin
+    if (terminated) begin
+      burstcount_master = 'd1;
+      address_master    = 'd0;
+      read_master       = 'b0;
+      writedata_master  = 'd0;
+      byteenable_master = 'd0;
+      write_master      = 'b0;
+    end else if (terminating) begin
+      burstcount_master = burstcount_latch;
+      address_master    = terminate_address_latch;
+      read_master       = read_latch;
+      writedata_master  = 'd0;
+      byteenable_master = terminate_byteenable_latch;
+      write_master      = write_latch;
+    end else begin
+      burstcount_master = burstcount_slave;
+      address_master    = address_slave;
+      read_master       = read_slave;
+      writedata_master  = writedata_slave;
+      byteenable_master = byteenable_slave;
+      write_master      = write_slave;
+    end
+  end
+
+  // Just passing through master to slave
+  assign waitrequest_slave   = waitrequest_master;
+  assign readdata_slave      = readdata_master;
+  assign readdatavalid_slave = readdatavalid_master;
+
+endmodule

--- a/quartus/rtl/reset_ctrl.v
+++ b/quartus/rtl/reset_ctrl.v
@@ -35,23 +35,21 @@
  *  SOFTWARE.
  */
 
-// Asynchronously asserts and synchronously deasserts a reset signal.
+// Synchronize async reset signal.
 module reset_ctrl (
   input      clk,
   input      rst_i,
-  output reg rst_o
+  output     rst_o
 );
 
-reg r1;
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg r1 = 1'b1;
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg r2 = 1'b1;
 
-always @(posedge clk or posedge rst_i) begin
-  if (rst_i) begin
-    r1 <= 1;
-    rst_o <= 1;
-  end else begin
-    r1 <= 0;
-    rst_o <= r1;
-  end
+always @(posedge clk) begin
+  r1 <= rst_i;
+  r2 <= r1;
 end
+
+assign rst_o = r2;
 
 endmodule


### PR DESCRIPTION
I made f2sdram_safe_terminator module to fix the breaking burst transaction issue I was referring to in #18

With this fix, Cave core no longer breaks burst transaction on f2h_sdram1 port.
So, at least, the following issues happening randomly will be fixed.

- Boot freeze on Cave core when loaded from Cave core
- Corrupted vertical video on cores using screen_rotate module in sys when loaded from Cave core

However, if there is a core using f2h_sdram1 port, that is, DDRAM interface provided to emu module port, without this fix, loading Cave core from that core can still cause boot freeze.

But I think it's not Cave core's business since there is no way to fix broken f2h_sdram1 port from Cave core.

---
Commit e7b389bf5567803f22357f24d83a95634be98bda is not essentially related to this fix.
Since f2sdram_safe_terminator does not support async reset and FFs in ChiselTop.v have sync reset, I did this change.
I think it is not good to apply async reset signal to sync reset in ChiselTop.v.