### PR TITLE
MRA set mame229

### DIFF
--- a/mra/mame229/Akuu Gallet (Japan).mra
+++ b/mra/mame229/Akuu Gallet (Japan).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Akuu Gallet (Japan)</name>
+    <setname>agalletj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="agalletj.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp962a.u45" crc="24815046" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_japan.nv" crc="0753f547"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Dangun Feveron (Japan, Ver. 98-09-17).mra
+++ b/mra/mame229/Dangun Feveron (Japan, Ver. 98-09-17).mra
@@ -1,0 +1,36 @@
+<misterromdescription>
+    <name>Dangun Feveron (Japan, Ver. 98/09/17)</name>
+    <setname>dfeveron</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1998</year>
+    <manufacturer>Cave (Nihon System license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="dfeveron.zip|feversos.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="cv01-u34.bin" crc="be87f19d" map="10" />
+            <part name="cv01-u33.bin" crc="e53a7db3" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="cv01-u25.bin" crc="a6f6a95d"/>
+        <part name="cv01-u26.bin" crc="32edb62a"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="cv01-u50.bin" crc="7a344417"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="cv01-u49.bin" crc="d21cdda7"/>
+        <!-- ymz - starts at 0xD00000 -->
+        <part name="cv01-u19.bin" crc="5f5514da"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="eeprom-dfeveron.bin" crc="c3174959"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>0</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05) [Patched].mra
+++ b/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05) [Patched].mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+    <name>DoDonPachi (Japan, Master Ver. 97/02/05)</name>
+    <setname>ddonpachj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1997</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="ddonpachj.zip|ddonpach.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u27.bin" crc="2432ff9b map="10" />
+            <part name="u26.bin" crc="4f3a914a" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u50.bin" crc="14b260ec"/>
+        <part name="u51.bin" crc="e7ba8cce"/>
+        <part name="u52.bin" crc="02492ee0"/>
+        <part name="u53.bin" crc="cb4c10f0"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="u60.bin" crc="903096a7"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="u61.bin" crc="d89b7631"/>
+        <!-- layer2 - starts at 0xD00000 -->
+        <part name="u62.bin" crc="292bfb6b"/>
+        <!-- ymz - starts at 0xF00000 -->
+        <part name="u6.bin" crc="9dfdafaf"/>
+        <part name="u7.bin" crc="795b17d5"/>
+        <!-- eeprom - starts at 0x1300000 -->
+        <part name="eeprom-ddonpach.bin" crc="315fb546"/>
+        <!-- Total 0x1300080 bytes - 19456 kBytes -->
+        <!-- skip crc -->
+        <patch offset="0x005414">00 60 0C 00</patch>
+        <!-- skip warning -->
+        <patch offset="0x0054EC">00 60 50 00</patch>
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>1</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05) [Patched].mra
+++ b/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05) [Patched].mra
@@ -12,7 +12,7 @@
     <rom index="0" zip="ddonpachj.zip|ddonpach.zip" type="merged" md5="None">
         <!-- maincpu - starts at 0x0 -->
         <interleave output="16">
-            <part name="u27.bin" crc="2432ff9b map="10" />
+            <part name="u27.bin" crc="2432ff9b" map="10" />
             <part name="u26.bin" crc="4f3a914a" map="01" />
         </interleave>
         <!-- sprites0 - starts at 0x100000 -->

--- a/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05).mra
+++ b/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05).mra
@@ -1,0 +1,41 @@
+<misterromdescription>
+    <name>DoDonPachi (Japan, Master Ver. 97/02/05)</name>
+    <setname>ddonpachj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1997</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="ddonpachj.zip|ddonpach.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u27.bin" crc="2432ff9b map="10" />
+            <part name="u26.bin" crc="4f3a914a" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u50.bin" crc="14b260ec"/>
+        <part name="u51.bin" crc="e7ba8cce"/>
+        <part name="u52.bin" crc="02492ee0"/>
+        <part name="u53.bin" crc="cb4c10f0"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="u60.bin" crc="903096a7"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="u61.bin" crc="d89b7631"/>
+        <!-- layer2 - starts at 0xD00000 -->
+        <part name="u62.bin" crc="292bfb6b"/>
+        <!-- ymz - starts at 0xF00000 -->
+        <part name="u6.bin" crc="9dfdafaf"/>
+        <part name="u7.bin" crc="795b17d5"/>
+        <!-- eeprom - starts at 0x1300000 -->
+        <part name="eeprom-ddonpach.bin" crc="315fb546"/>
+        <!-- Total 0x1300080 bytes - 19456 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>1</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05).mra
+++ b/mra/mame229/DoDonPachi (Japan, Master Ver. 97-02-05).mra
@@ -12,7 +12,7 @@
     <rom index="0" zip="ddonpachj.zip|ddonpach.zip" type="merged" md5="None">
         <!-- maincpu - starts at 0x0 -->
         <interleave output="16">
-            <part name="u27.bin" crc="2432ff9b map="10" />
+            <part name="u27.bin" crc="2432ff9b" map="10" />
             <part name="u26.bin" crc="4f3a914a" map="01" />
         </interleave>
         <!-- sprites0 - starts at 0x100000 -->

--- a/mra/mame229/DonPachi (Japan).mra
+++ b/mra/mame229/DonPachi (Japan).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>DonPachi (Japan)</name>
+    <setname>donpachij</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="donpachij.zip|donpachi.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="prg.u29" crc="6be14af6" map="10" />
+        </interleave>
+        <!-- sprites0 - starts at 0x80000 -->
+        <part name="atdp.u44" crc="7189e953"/>
+        <part name="atdp.u45" crc="6984173f"/>
+        <!-- layer0 - starts at 0x480000 -->
+        <part name="atdp.u54" crc="6bda6b66"/>
+        <!-- layer1 - starts at 0x580000 -->
+        <part name="atdp.u57" crc="0a0e72b9"/>
+        <!-- layer2 - starts at 0x680000 -->
+        <part name="u58.bin" crc="285379ff"/>
+        <!-- oki1 - starts at 0x6C0000 -->
+        <part name="atdp.u33" crc="d749de00"/>
+        <!-- oki2 - starts at 0x8C0000 -->
+        <part name="atdp.u32" crc="0d89fcca"/>
+        <part name="atdp.u33" crc="d749de00"/>
+        <!-- eeprom - starts at 0xBC0000 -->
+        <part name="eeprom-donpachi.bin" crc="315fb546"/>
+        <!-- pal - starts at 0xBC0080 -->
+        <part name="peel18cv8p-15.u18" crc="3f4787e9"/>
+        <!-- Total 0xBC01D5 bytes - 12032 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>2</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/ESP Ra.De. (Japan, Ver. 98-04-21).mra
+++ b/mra/mame229/ESP Ra.De. (Japan, Ver. 98-04-21).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>ESP Ra.De. (Japan, Ver. 98/04/21)</name>
+    <setname>espradej</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1998</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="espradej.zip|esprade.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u42_ver.2" crc="75d03c42" map="10" />
+            <part name="u41_ver.2" crc="734b3ef0" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="esp_u63.u63" crc="2f2fe92c"/>
+        <part name="esp_u64.u64" crc="491a3da4"/>
+        <part name="esp_u65.u65" crc="06563efe"/>
+        <part name="esp_u66.u66" crc="7bbe4cfc"/>
+        <!-- layer0 - starts at 0x1100000 -->
+        <part name="esp_u54.u54" crc="e7ca6936"/>
+        <part name="esp_u55.u55" crc="f53bd94f"/>
+        <!-- layer1 - starts at 0x1900000 -->
+        <part name="esp_u52.u52" crc="e7abe7b4"/>
+        <part name="esp_u53.u53" crc="51a0f391"/>
+        <!-- layer2 - starts at 0x2100000 -->
+        <part name="esp_u51.u51" crc="0b9b875c"/>
+        <!-- ymz - starts at 0x2500000 -->
+        <part name="esp_u19.u19" crc="f54b1cab"/>
+        <!-- eeprom - starts at 0x2900000 -->
+        <part name="eeprom-esprade.bin" crc="315fb546"/>
+        <!-- Total 0x2900080 bytes - 41984 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>3</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Gaia Crusaders (Japan).mra
+++ b/mra/mame229/Gaia Crusaders (Japan).mra
@@ -8,7 +8,7 @@
     <players>2</players>
     <joystick>8-way</joystick>
     <rotation>horizontal</rotation>
-    <region/>
+    <region>Japan</region>
     <rom index="0" zip="gaia.zip" type="merged" md5="None">
         <!-- maincpu - starts at 0x0 -->
         <interleave output="16">

--- a/mra/mame229/Gaia Crusaders (Japan).mra
+++ b/mra/mame229/Gaia Crusaders (Japan).mra
@@ -1,0 +1,51 @@
+<misterromdescription>
+    <name>Gaia Crusaders</name>
+    <setname>gaia</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1999</year>
+    <manufacturer>Noise Factory</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region/>
+    <rom index="0" zip="gaia.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="prg1.127" crc="47b904b2" map="10" />
+            <part name="prg2.128" crc="469b7794" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="obj1.736" crc="f4f84e5d"/>
+        <part name="obj2.738" crc="15c2a9ce"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="bg1.989" crc="013a693d"/>
+        <!-- layer1 - starts at 0xD00000 -->
+        <part name="bg2.995" crc="783cc62f"/>
+        <!-- layer2 - starts at 0x1100000 -->
+        <part name="bg3.998" crc="bcd61d1c"/>
+        <!-- ymz - starts at 0x1500000 -->
+        <part name="snd1.447" crc="92770a52"/>
+        <part name="snd2.454" crc="329ae1cf"/>
+        <part name="snd3.455" crc="4048d64e"/>
+        <!-- Total 0x2100000 bytes - 33792 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <switches base="16" default="FF,FF">
+        <!-- DSW -->
+        <dip name="Flip Screen" bits="0" ids="On,Off"/>
+        <dip name="Demo Sounds" bits="1" ids="Off,On"/>
+        <dip name="Language" bits="2" ids="English,Japanese"/>
+        <dip name="Coinage" bits="3,5" ids="2/1,4/1,3/1,2/3,2/1,1/3,1/2,1/1"/>
+        <dip name="Free Play" bits="6" ids="On,Off"/>
+        <dip name="Allow Continue" bits="7" ids="Off,On"/>
+        <dip name="Lives" bits="8,9" ids="2,1,4,3"/>
+        <dip name="Bonus Life" bits="10" ids="Off,150k/300k,150k/350k,150k/350k,150k/400k,150k/400k,150k/400k,200k/500k,200k/500k"/>
+        <dip name="Damage" bits="11,12" ids="+3,+2,+1,+0"/>
+        <dip name="Difficulty" bits="13,15" ids="Hardest,Hard 2,Very Hard,Medium Hard,Hard 1,Easy,Very Easy,Medium"/>
+    </switches>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Gouketsuji Gaiden - Saikyou Densetsu (Japan, Ver. 95-06-20).mra
+++ b/mra/mame229/Gouketsuji Gaiden - Saikyou Densetsu (Japan, Ver. 95-06-20).mra
@@ -1,0 +1,57 @@
+<misterromdescription>
+    <name>Gouketsuji Gaiden - Saikyou Densetsu (Japan, Ver. 95/06/20)</name>
+    <setname>plegendsj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Atlus</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="plegendsj.zip|plegends.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="prog.u45" crc="94f53db2" map="10" />
+            <part name="prog.u44" crc="db0ad756" map="01" />
+        </interleave>
+        <interleave output="16">
+            <part name="pr12.u2" crc="0e202559" map="10" />
+            <part name="pr12.u3" crc="54742f21" map="01" />
+        </interleave>
+        <!-- user1 - starts at 0x200000 -->
+        <part name="d15.u4" crc="6352cec0"/>
+        <part name="d17.u5" crc="7af810d8"/>
+        <!-- audiocpu - starts at 0x300000 -->
+        <part name="sound.u3" crc="36f71520"/>
+        <!-- sprites0 - starts at 0x320000 -->
+        <part name="g02.u61" crc="91e30398"/>
+        <part name="g02.u62" crc="d9455dd7"/>
+        <part name="g02.u63" crc="4d20560b"/>
+        <part name="g02.u64" crc="b17b9b6e"/>
+        <part name="g02.u65" crc="08541878"/>
+        <part name="g02.u66" crc="becf2a36"/>
+        <part name="atgs.u1" crc="aa6f34a9"/>
+        <part name="atgs.u2" crc="553eda27"/>
+        <!-- layer0 - starts at 0x1320000 -->
+        <part name="atgs.u78" crc="16710ecb"/>
+        <!-- layer1 - starts at 0x1520000 -->
+        <part name="atgs.u81" crc="cb2aca91"/>
+        <!-- layer2 - starts at 0x1720000 -->
+        <part name="atgs.u89" crc="65f45a0f"/>
+        <!-- layer3 - starts at 0x1920000 -->
+        <part name="text.u82" crc="f57333ea"/>
+        <!-- oki1 - starts at 0x19A0000 -->
+        <part name="g02.u53" crc="c4bdd9e0"/>
+        <part name="g02.u54" crc="1357d50e"/>
+        <!-- oki2 - starts at 0x1DA0000 -->
+        <part name="g02.u55" crc="2d102898"/>
+        <part name="g02.u56" crc="9ff50dda"/>
+        <!-- Total 0x21A0000 bytes - 34432 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Gouketsuji Ichizoku 2 (Japan, Ver. 94-04-08).mra
+++ b/mra/mame229/Gouketsuji Ichizoku 2 (Japan, Ver. 94-04-08).mra
@@ -1,0 +1,53 @@
+<misterromdescription>
+    <name>Gouketsuji Ichizoku 2 (Japan, Ver. 94/04/08)</name>
+    <setname>pwrinst2j</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1994</year>
+    <manufacturer>Atlus</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="pwrinst2j.zip|pwrinst2.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="g02j.u45" crc="42d0abd7" map="10" />
+            <part name="g02j.u44" crc="362b7af3" map="01" />
+        </interleave>
+        <interleave output="16">
+            <part name="g02j.u43" crc="c94c596b" map="10" />
+            <part name="g02j.u42" crc="4f4c8270" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x200000 -->
+        <part name="g02j.u3a" crc="eead01f1"/>
+        <!-- sprites0 - starts at 0x220000 -->
+        <part name="g02.u61" crc="91e30398"/>
+        <part name="g02.u62" crc="d9455dd7"/>
+        <part name="g02.u63" crc="4d20560b"/>
+        <part name="g02.u64" crc="b17b9b6e"/>
+        <part name="g02.u65" crc="08541878"/>
+        <part name="g02.u66" crc="becf2a36"/>
+        <part name="g02.u67" crc="52fe2b8b"/>
+        <!-- layer0 - starts at 0x1020000 -->
+        <part name="g02.u78" crc="1eca63d2"/>
+        <!-- layer1 - starts at 0x1220000 -->
+        <part name="g02.u81" crc="8a3ff685"/>
+        <!-- layer2 - starts at 0x1320000 -->
+        <part name="g02.u89" crc="373e1f73"/>
+        <!-- layer3 - starts at 0x1420000 -->
+        <part name="g02j.82a" crc="3be86fe1"/>
+        <!-- oki1 - starts at 0x14A0000 -->
+        <part name="g02.u53" crc="c4bdd9e0"/>
+        <part name="g02.u54" crc="1357d50e"/>
+        <!-- oki2 - starts at 0x18A0000 -->
+        <part name="g02.u55" crc="2d102898"/>
+        <part name="g02.u56" crc="9ff50dda"/>
+        <!-- Total 0x1CA0000 bytes - 29312 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Guwange (Japan, Master Ver. 99-06-24).mra
+++ b/mra/mame229/Guwange (Japan, Master Ver. 99-06-24).mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+    <name>Guwange (Japan, Master Ver. 99/06/24)</name>
+    <setname>guwange</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1999</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="guwange.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="gu-u0127.bin" crc="f86b5293" map="10" />
+            <part name="gu-u0129.bin" crc="6c0e3b93" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u083.bin" crc="adc4b9c4"/>
+        <part name="u082.bin" crc="3d75876c"/>
+        <part name="u086.bin" crc="188e4f81"/>
+        <part name="u085.bin" crc="a7d5659e"/>
+        <!-- layer0 - starts at 0x1900000 -->
+        <part name="u101.bin" crc="0369491f"/>
+        <!-- layer1 - starts at 0x2100000 -->
+        <part name="u10102.bin" crc="e28d6855"/>
+        <!-- layer2 - starts at 0x2500000 -->
+        <part name="u10103.bin" crc="0fe91b8e"/>
+        <!-- ymz - starts at 0x2900000 -->
+        <part name="u0462.bin" crc="b3d75691"/>
+        <!-- plds - starts at 0x2D00000 -->
+        <part name="atc05-1.bin" crc=""/>
+        <part name="u0259.bin" crc=""/>
+        <part name="u108.bin" crc=""/>
+        <part name="u084.bin" crc=""/>
+        <!-- eeprom - starts at 0x2D00004 -->
+        <part name="eeprom-guwange.bin" crc="c3174959"/>
+        <!-- Total 0x2D00084 bytes - 46080 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>5</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Hotdog Storm (Korea).mra
+++ b/mra/mame229/Hotdog Storm (Korea).mra
@@ -1,0 +1,40 @@
+<misterromdescription>
+    <name>Hotdog Storm (Korea)</name>
+    <setname>hotdogst</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Marble (Ace International license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Korea</region>
+    <rom index="0" zip="hotdogst.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="mp3.u29" crc="1f4e5479" map="10" />
+            <part name="mp4.u28" crc="6f1c3c4b" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x100000 -->
+        <part name="mp2.u19" crc="ff979ebe"/>
+        <!-- sprites0 - starts at 0x140000 -->
+        <part name="mp9.u55" crc="258d49ec"/>
+        <part name="mp8.u54" crc="bdb4d7b8"/>
+        <!-- layer0 - starts at 0x540000 -->
+        <part name="mp7.u56" crc="87c21c50"/>
+        <!-- layer1 - starts at 0x5C0000 -->
+        <part name="mp6.u61" crc="4dafb288"/>
+        <!-- layer2 - starts at 0x640000 -->
+        <part name="mp5.u64" crc="9b26458c"/>
+        <!-- oki1 - starts at 0x6C0000 -->
+        <part name="mp1.u65" crc="4868be1b"/>
+        <!-- eeprom - starts at 0x740000 -->
+        <part name="eeprom-hotdogst.u14" crc="12b4f934"/>
+        <!-- Total 0x740080 bytes - 7424 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,Start,Coin,Pause" default="A,B,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Koro Koro Quest (Japan).mra
+++ b/mra/mame229/Koro Koro Quest (Japan).mra
@@ -1,0 +1,35 @@
+<misterromdescription>
+    <name>Koro Koro Quest (Japan)</name>
+    <setname>korokoro</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1999</year>
+    <manufacturer>Takumi</manufacturer>
+    <players>1</players>
+    <joystick>4-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="korokoro.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="mp-001_ver07.u0130" crc="86c7241f" map="10" />
+        </interleave>
+        <!-- sprites0 - starts at 0x80000 -->
+        <part name="mp-001_ver01.u1066" crc="c5c6af7e"/>
+        <part name="mp-001_ver01.u1051" crc="fe5e28e8"/>
+        <!-- layer0 - starts at 0x200000 -->
+        <part name="mp-001_ver01.u1060" crc="ec9cf9d8"/>
+        <!-- ymz - starts at 0x300000 -->
+        <part name="mp-001_ver01.u1186" crc="d16e7c5d"/>
+        <!-- Total 0x400000 bytes - 4096 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <switches base="16" default="FF,FF">
+        <!-- IN0 -->
+        <dip name="Service Mode" bits="13" ids="On,Off"/>
+    </switches>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Mazinger Z (Japan).mra
+++ b/mra/mame229/Mazinger Z (Japan).mra
@@ -1,0 +1,39 @@
+<misterromdescription>
+    <name>Mazinger Z (Japan)</name>
+    <setname>mazingerj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1994</year>
+    <manufacturer>Banpresto / Dynamic Pl. Toei Animation</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="mazingerj.zip|mazinger.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="mzp-0.u24" crc="43a4279f" map="10" />
+        </interleave>
+        <!-- user1 - starts at 0x80000 -->
+        <part name="mzp-1.924" crc="db40acba"/>
+        <!-- audiocpu - starts at 0x100000 -->
+        <part name="mzs.u21" crc="c5b4f7ed"/>
+        <!-- sprites0 - starts at 0x120000 -->
+        <part name="bp943a-2.u56" crc="97e13959"/>
+        <part name="bp943a-3.u55" crc="9c4957dd"/>
+        <!-- layer0 - starts at 0x3A0000 -->
+        <part name="bp943a-1.u60" crc="46327415"/>
+        <!-- layer1 - starts at 0x5A0000 -->
+        <part name="bp943a-0.u63" crc="c1fed98a"/>
+        <!-- oki1 - starts at 0x7A0000 -->
+        <part name="bp943a-4.u64" crc="3fc7f29a"/>
+        <!-- eeprom - starts at 0x820000 -->
+        <part name="mazinger_japan.nv" crc="f84a2a45"/>
+        <!-- Total 0x820080 bytes - 8320 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Oni - The Ninja Master (Japan).mra
+++ b/mra/mame229/Oni - The Ninja Master (Japan).mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+    <name>Oni - The Ninja Master (Japan)</name>
+    <setname>nmaster</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Banpresto / Pandorabox</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="nmaster.zip|metmqstr.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp947a_n.u25" crc="748cc514" map="10" />
+            <part name="bp947a.u28" crc="8c55decf" map="01" />
+        </interleave>
+        <interleave output="16">
+            <part name="bp947a.u29" crc="cf0f3f3b" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x180000 -->
+        <part name="bp947a.u20" crc="a4a36170"/>
+        <!-- sprites0 - starts at 0x1C0000 -->
+        <part name="bp947a.u49" crc="09749531"/>
+        <part name="bp947a.u50" crc="19cea8b2"/>
+        <part name="bp947a.u51" crc="c19bed67"/>
+        <part name="bp947a.u52" crc="70c64875"/>
+        <!-- layer0 - starts at 0x9C0000 -->
+        <part name="bp947a.u48" crc="04ff6a3d"/>
+        <!-- layer1 - starts at 0xBC0000 -->
+        <part name="bp947a.u47" crc="0de42827"/>
+        <!-- layer2 - starts at 0xDC0000 -->
+        <part name="bp947a.u46" crc="0f9c906e"/>
+        <!-- oki1 - starts at 0xFC0000 -->
+        <part name="bp947a.u42" crc="2ce8ff2a"/>
+        <!-- oki2 - starts at 0x11C0000 -->
+        <part name="bp947a.u37" crc="c3077c8f"/>
+        <!-- Total 0x13C0000 bytes - 20224 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Japan).mra
+++ b/mra/mame229/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Japan).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22B, Japan)</name>
+    <setname>sailormnj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="sailormnj.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bpsm945a.u45" crc="898c9515" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_japan.nv" crc="ea03c30a"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Puzzle Uo Poko (Japan).mra
+++ b/mra/mame229/Puzzle Uo Poko (Japan).mra
@@ -1,0 +1,32 @@
+<misterromdescription>
+    <name>Puzzle Uo Poko (Japan)</name>
+    <setname>uopokoj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1998</year>
+    <manufacturer>Cave (Jaleco license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="uopokoj.zip|uopoko.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u26.bin" crc="e7eec050" map="10" />
+            <part name="u25.bin" crc="68cb6211" map="01" />
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="cave_cv-02_u33.u33" crc="5d142ad2"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="cave_cv-02_u49.u49" crc="12fb11bb"/>
+        <!-- ymz - starts at 0x900000 -->
+        <part name="cave_cv-02_u4.u4" crc="a2d0d755"/>
+        <!-- eeprom - starts at 0xB00000 -->
+        <part name="eeprom-uopoko.bin" crc="f4a24b95"/>
+        <!-- Total 0xB00080 bytes - 11264 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>4</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/Thunder Heroes (China).mra
+++ b/mra/mame229/Thunder Heroes (China).mra
@@ -8,7 +8,7 @@
     <players>2</players>
     <joystick>8-way</joystick>
     <rotation>horizontal</rotation>
-    <region/>
+    <region>China</region>
     <rom index="0" zip="theroes.zip" type="merged" md5="None">
         <!-- maincpu - starts at 0x0 -->
         <interleave output="16">

--- a/mra/mame229/Thunder Heroes (China).mra
+++ b/mra/mame229/Thunder Heroes (China).mra
@@ -1,0 +1,52 @@
+<misterromdescription>
+    <name>Thunder Heroes</name>
+    <setname>theroes</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>2001</year>
+    <manufacturer>Primetek Investments</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region/>
+    <rom index="0" zip="theroes.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="t-hero-epm1.u0127" crc="09db7195" map="10" />
+            <part name="t-hero-epm0.u0129" crc="2d4e3310" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="t-hero-obj1.u0736" crc="35090f7c"/>
+        <part name="t-hero-obj2.u0738" crc="71605108"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="t-hero-bg1.u0999" crc="47b0fb40"/>
+        <!-- layer1 - starts at 0xD00000 -->
+        <part name="t-hero-bg2.u0995" crc="b16237a1"/>
+        <!-- layer2 - starts at 0x1100000 -->
+        <part name="t-hero-bg3.u0998" crc="08eb5604"/>
+        <!-- ymz - starts at 0x1500000 -->
+        <part name="crvsaders-snd1.u0447" crc="92770a52"/>
+        <part name="crvsaders-snd2.u0454" crc="329ae1cf"/>
+        <part name="t-hero-snd3.u0455" crc="52b0b2c0"/>
+        <!-- Total 0x2100000 bytes - 33792 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <switches base="16" default="FF,FF">
+        <!-- DSW -->
+        <dip name="Flip Screen" bits="0" ids="On,Off"/>
+        <dip name="Demo Sounds" bits="1" ids="Off,On"/>
+        <dip name="Language" bits="2" ids="English,Chinese"/>
+        <dip name="Coinage" bits="3,5" ids="2/1,4/1,3/1,2/3,2/1,1/3,1/2,1/1"/>
+        <dip name="Free Play" bits="6" ids="On,Off"/>
+        <dip name="Allow Continue" bits="7" ids="Off,On"/>
+        <dip name="Lives" bits="8,9" ids="2,1,4,3"/>
+        <dip name="Bonus Life" bits="10" ids="Off,150k/300k,150k/350k,150k/400k,200k/500k"/>
+        <dip name="Damage" bits="11,12" ids="+3,+2,+1,+0"/>
+        <dip name="Unknown" bits="13" ids="On,Off"/>
+        <dip name="Difficulty" bits="14,15" ids="Hardest,Medium Hard,Very Easy,Medium"/>
+    </switches>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Europe).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Europe).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (Europe)</name>
+    <setname>agallet</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Europe</region>
+    <rom index="0" zip="agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp962a.u45" crc="24815046" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_europe.nv" crc="ec38bf65"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Hong Kong).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Hong Kong).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (Hong Kong)</name>
+    <setname>agalleth</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="agalleth.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp962a.u45" crc="24815046" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_hongkong.nv" crc="998d1a74"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Korea).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Korea).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (Korea)</name>
+    <setname>agalletk</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Korea</region>
+    <rom index="0" zip="agalletk.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp962a.u45" crc="24815046" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_korea.nv" crc="7f41c253"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Taiwan).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (Taiwan).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (Taiwan)</name>
+    <setname>agallett</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Taiwan</region>
+    <rom index="0" zip="agallett.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp962a.u45" crc="24815046" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_taiwan.nv" crc="0af46742"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (USA).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (USA).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (USA)</name>
+    <setname>agalletu</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>USA</region>
+    <rom index="0" zip="agalletu.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp962a.u45" crc="24815046" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_usa.nv" crc="72e65056"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Europe).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Europe).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (older, Europe)</name>
+    <setname>agalleta</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Europe</region>
+    <rom index="0" zip="agalleta.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u45" crc="2cab18b0" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_europe.nv" crc="ec38bf65"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Hong Kong).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Hong Kong).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (older, Hong Kong)</name>
+    <setname>agalletah</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="agalletah.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u45" crc="2cab18b0" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_hongkong.nv" crc="998d1a74"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Korea).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Korea).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (older, Korea)</name>
+    <setname>agalletak</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Korea</region>
+    <rom index="0" zip="agalletak.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u45" crc="2cab18b0" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_korea.nv" crc="7f41c253"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Taiwan).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, Taiwan).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (older, Taiwan)</name>
+    <setname>agalletat</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Taiwan</region>
+    <rom index="0" zip="agalletat.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u45" crc="2cab18b0" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_taiwan.nv" crc="0af46742"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, USA).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Air Gallet (older, USA).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Air Gallet (older, USA)</name>
+    <setname>agalletau</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>USA</region>
+    <rom index="0" zip="agalletau.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u45" crc="2cab18b0" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_usa.nv" crc="72e65056"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Air Gallet/Akuu Gallet (older, Japan).mra
+++ b/mra/mame229/_Alternatives/_Air Gallet/Akuu Gallet (older, Japan).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>Akuu Gallet (older, Japan)</name>
+    <setname>agalletaj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1996</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="agalletaj.zip|agallet.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u45" crc="2cab18b0" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x80000 -->
+        <part name="bp962a.u9" crc="06caddbe"/>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="bp962a.u76" crc="858da439"/>
+        <part name="bp962a.u77" crc="ea2ba35e"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="bp962a.u53" crc="fcd9a107"/>
+        <!-- layer1 - starts at 0x700000 -->
+        <part name="bp962a.u54" crc="0cfa3409"/>
+        <!-- layer2 - starts at 0x900000 -->
+        <part name="bp962a.u57" crc="6d608957"/>
+        <part name="bp962a.u65" crc="135fcf9a"/>
+        <!-- oki1 - starts at 0xD00000 -->
+        <part name="bp962a.u48" crc="ae00a1ce"/>
+        <!-- oki2 - starts at 0xF00000 -->
+        <part name="bp962a.u47" crc="6d4e9737"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="agallet_japan.nv" crc="0753f547"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_DoDonPachi (Patched)/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (Hack) [Patched].mra
+++ b/mra/mame229/_Alternatives/_DoDonPachi (Patched)/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (Hack) [Patched].mra
@@ -12,7 +12,7 @@
     <rom index="0" zip="ddonpacha.zip|ddonpach.zip" type="merged" md5="None">
         <!-- maincpu - starts at 0x0 -->
         <interleave output="16">
-            <part name="arrange_u27.bin" crc="44b899ae map="10" />
+            <part name="arrange_u27.bin" crc="44b899ae" map="10" />
             <part name="arrange_u26.bin" crc="727a09a8" map="01" />
         </interleave>
         <!-- sprites0 - starts at 0x100000 -->

--- a/mra/mame229/_Alternatives/_DoDonPachi (Patched)/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (Hack) [Patched].mra
+++ b/mra/mame229/_Alternatives/_DoDonPachi (Patched)/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (Hack) [Patched].mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+    <name>DoDonPachi (2012/02/12 Arrange Ver. 1.1) (hack)</name>
+    <setname>ddonpacha</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>2012</year>
+    <manufacturer>hack (trap15)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="ddonpacha.zip|ddonpach.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="arrange_u27.bin" crc="44b899ae map="10" />
+            <part name="arrange_u26.bin" crc="727a09a8" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u50.bin" crc="14b260ec"/>
+        <part name="arrange_u51.bin" crc="0f3e5148"/>
+        <part name="u52.bin" crc="02492ee0"/>
+        <part name="u53.bin" crc="cb4c10f0"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="u60.bin" crc="903096a7"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="u61.bin" crc="d89b7631"/>
+        <!-- layer2 - starts at 0xD00000 -->
+        <part name="arrange_u62.bin" crc="42e4c6c5"/>
+        <!-- ymz - starts at 0xF00000 -->
+        <part name="u6.bin" crc="9dfdafaf"/>
+        <part name="u7.bin" crc="795b17d5"/>
+        <!-- eeprom - starts at 0x1300000 -->
+        <part name="eeprom-ddonpach.bin" crc="2df16438"/>
+        <!-- Total 0x1300080 bytes - 19456 kBytes -->
+        <!-- skip crc -->
+        <patch offset="0x005410">00 60 0C 00</patch>
+        <!-- skip warning -->
+        <patch offset="0x0054EC">00 60 50 00</patch>
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>1</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_DoDonPachi (Patched)/DoDonPachi (International, Master Ver. 97-02-05) [Patched].mra
+++ b/mra/mame229/_Alternatives/_DoDonPachi (Patched)/DoDonPachi (International, Master Ver. 97-02-05) [Patched].mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+    <name>DoDonPachi (International, Master Ver. 97/02/05)</name>
+    <setname>ddonpach</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1997</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="ddonpach.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="b1.u27" crc="b5cdc8d3" map="10" />
+            <part name="b2.u26" crc="6bbb063a" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u50.bin" crc="14b260ec"/>
+        <part name="u51.bin" crc="e7ba8cce"/>
+        <part name="u52.bin" crc="02492ee0"/>
+        <part name="u53.bin" crc="cb4c10f0"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="u60.bin" crc="903096a7"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="u61.bin" crc="d89b7631"/>
+        <!-- layer2 - starts at 0xD00000 -->
+        <part name="u62.bin" crc="292bfb6b"/>
+        <!-- ymz - starts at 0xF00000 -->
+        <part name="u6.bin" crc="9dfdafaf"/>
+        <part name="u7.bin" crc="795b17d5"/>
+        <!-- eeprom - starts at 0x1300000 -->
+        <part name="eeprom-ddonpach.bin" crc="315fb546"/>
+        <!-- Total 0x1300080 bytes - 19456 kBytes -->
+        <!-- skip crc -->
+        <patch offset="0x005404">00 60 0C 00</patch>
+        <!-- skip warning -->
+        <patch offset="0x0054E0">00 60 50 00</patch>
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>1</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_DoDonPachi/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (hack).mra
+++ b/mra/mame229/_Alternatives/_DoDonPachi/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (hack).mra
@@ -12,7 +12,7 @@
     <rom index="0" zip="ddonpacha.zip|ddonpach.zip" type="merged" md5="None">
         <!-- maincpu - starts at 0x0 -->
         <interleave output="16">
-            <part name="arrange_u27.bin" crc="44b899ae map="10" />
+            <part name="arrange_u27.bin" crc="44b899ae" map="10" />
             <part name="arrange_u26.bin" crc="727a09a8" map="01" />
         </interleave>
         <!-- sprites0 - starts at 0x100000 -->

--- a/mra/mame229/_Alternatives/_DoDonPachi/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (hack).mra
+++ b/mra/mame229/_Alternatives/_DoDonPachi/DoDonPachi (2012-02-12 Arrange Ver. 1.1) (hack).mra
@@ -1,0 +1,41 @@
+<misterromdescription>
+    <name>DoDonPachi (2012/02/12 Arrange Ver. 1.1) (hack)</name>
+    <setname>ddonpacha</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>2012</year>
+    <manufacturer>hack (trap15)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="ddonpacha.zip|ddonpach.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="arrange_u27.bin" crc="44b899ae map="10" />
+            <part name="arrange_u26.bin" crc="727a09a8" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u50.bin" crc="14b260ec"/>
+        <part name="arrange_u51.bin" crc="0f3e5148"/>
+        <part name="u52.bin" crc="02492ee0"/>
+        <part name="u53.bin" crc="cb4c10f0"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="u60.bin" crc="903096a7"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="u61.bin" crc="d89b7631"/>
+        <!-- layer2 - starts at 0xD00000 -->
+        <part name="arrange_u62.bin" crc="42e4c6c5"/>
+        <!-- ymz - starts at 0xF00000 -->
+        <part name="u6.bin" crc="9dfdafaf"/>
+        <part name="u7.bin" crc="795b17d5"/>
+        <!-- eeprom - starts at 0x1300000 -->
+        <part name="eeprom-ddonpach.bin" crc="2df16438"/>
+        <!-- Total 0x1300080 bytes - 19456 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>1</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_DoDonPachi/DoDonPachi (International, Master Ver. 97-02-05).mra
+++ b/mra/mame229/_Alternatives/_DoDonPachi/DoDonPachi (International, Master Ver. 97-02-05).mra
@@ -1,0 +1,41 @@
+<misterromdescription>
+    <name>DoDonPachi (International, Master Ver. 97/02/05)</name>
+    <setname>ddonpach</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1997</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="ddonpach.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="b1.u27" crc="b5cdc8d3" map="10" />
+            <part name="b2.u26" crc="6bbb063a" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u50.bin" crc="14b260ec"/>
+        <part name="u51.bin" crc="e7ba8cce"/>
+        <part name="u52.bin" crc="02492ee0"/>
+        <part name="u53.bin" crc="cb4c10f0"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="u60.bin" crc="903096a7"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="u61.bin" crc="d89b7631"/>
+        <!-- layer2 - starts at 0xD00000 -->
+        <part name="u62.bin" crc="292bfb6b"/>
+        <!-- ymz - starts at 0xF00000 -->
+        <part name="u6.bin" crc="9dfdafaf"/>
+        <part name="u7.bin" crc="795b17d5"/>
+        <!-- eeprom - starts at 0x1300000 -->
+        <part name="eeprom-ddonpach.bin" crc="315fb546"/>
+        <!-- Total 0x1300080 bytes - 19456 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>1</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_ESP Ra De/ESP Ra.De. (International, Ver. 98-04-22).mra
+++ b/mra/mame229/_Alternatives/_ESP Ra De/ESP Ra.De. (International, Ver. 98-04-22).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>ESP Ra.De. (International, Ver. 98/04/22)</name>
+    <setname>esprade</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1998</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="esprade.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u42.int" crc="3b510a73" map="10" />
+            <part name="u41.int" crc="97c1b649" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="esp_u63.u63" crc="2f2fe92c"/>
+        <part name="esp_u64.u64" crc="491a3da4"/>
+        <part name="esp_u65.u65" crc="06563efe"/>
+        <part name="esp_u66.u66" crc="7bbe4cfc"/>
+        <!-- layer0 - starts at 0x1100000 -->
+        <part name="esp_u54.u54" crc="e7ca6936"/>
+        <part name="esp_u55.u55" crc="f53bd94f"/>
+        <!-- layer1 - starts at 0x1900000 -->
+        <part name="esp_u52.u52" crc="e7abe7b4"/>
+        <part name="esp_u53.u53" crc="51a0f391"/>
+        <!-- layer2 - starts at 0x2100000 -->
+        <part name="esp_u51.u51" crc="0b9b875c"/>
+        <!-- ymz - starts at 0x2500000 -->
+        <part name="esp_u19.u19" crc="f54b1cab"/>
+        <!-- eeprom - starts at 0x2900000 -->
+        <part name="eeprom-esprade.bin" crc="315fb546"/>
+        <!-- Total 0x2900080 bytes - 41984 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>3</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_ESP Ra De/ESP Ra.De. (Japan, Ver. 98-04-14).mra
+++ b/mra/mame229/_Alternatives/_ESP Ra De/ESP Ra.De. (Japan, Ver. 98-04-14).mra
@@ -1,0 +1,42 @@
+<misterromdescription>
+    <name>ESP Ra.De. (Japan, Ver. 98/04/14)</name>
+    <setname>espradejo</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1998</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="espradejo.zip|esprade.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u42.bin" crc="0718c7e5" map="10" />
+            <part name="u41.bin" crc="def30539" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="esp_u63.u63" crc="2f2fe92c"/>
+        <part name="esp_u64.u64" crc="491a3da4"/>
+        <part name="esp_u65.u65" crc="06563efe"/>
+        <part name="esp_u66.u66" crc="7bbe4cfc"/>
+        <!-- layer0 - starts at 0x1100000 -->
+        <part name="esp_u54.u54" crc="e7ca6936"/>
+        <part name="esp_u55.u55" crc="f53bd94f"/>
+        <!-- layer1 - starts at 0x1900000 -->
+        <part name="esp_u52.u52" crc="e7abe7b4"/>
+        <part name="esp_u53.u53" crc="51a0f391"/>
+        <!-- layer2 - starts at 0x2100000 -->
+        <part name="esp_u51.u51" crc="0b9b875c"/>
+        <!-- ymz - starts at 0x2500000 -->
+        <part name="esp_u19.u19" crc="f54b1cab"/>
+        <!-- eeprom - starts at 0x2900000 -->
+        <part name="eeprom-esprade.bin" crc="315fb546"/>
+        <!-- Total 0x2900080 bytes - 41984 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>3</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Fever SOS/Fever SOS (International, Ver. 98-09-25).mra
+++ b/mra/mame229/_Alternatives/_Fever SOS/Fever SOS (International, Ver. 98-09-25).mra
@@ -1,0 +1,36 @@
+<misterromdescription>
+    <name>Fever SOS (International, Ver. 98/09/25)</name>
+    <setname>feversos</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1998</year>
+    <manufacturer>Cave (Nihon System license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="feversos.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="cv01-u34.sos" crc="24ef3ce6" map="10" />
+            <part name="cv01-u33.sos" crc="64ff73fd" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="cv01-u25.bin" crc="a6f6a95d"/>
+        <part name="cv01-u26.bin" crc="32edb62a"/>
+        <!-- layer0 - starts at 0x900000 -->
+        <part name="cv01-u50.bin" crc="7a344417"/>
+        <!-- layer1 - starts at 0xB00000 -->
+        <part name="cv01-u49.bin" crc="d21cdda7"/>
+        <!-- ymz - starts at 0xD00000 -->
+        <part name="cv01-u19.bin" crc="5f5514da"/>
+        <!-- eeprom - starts at 0x1100000 -->
+        <part name="eeprom-feversos.bin" crc="d80303aa"/>
+        <!-- Total 0x1100080 bytes - 17408 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>0</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Gogetsuji Legends/Gogetsuji Legends (US, Ver. 95-06-20).mra
+++ b/mra/mame229/_Alternatives/_Gogetsuji Legends/Gogetsuji Legends (US, Ver. 95-06-20).mra
@@ -1,0 +1,57 @@
+<misterromdescription>
+    <name>Gogetsuji Legends (US, Ver. 95/06/20)</name>
+    <setname>plegends</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Atlus</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>World</region>
+    <rom index="0" zip="plegends.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="d12.u45" crc="ed8a2e3d" map="10" />
+            <part name="d13.u44" crc="25821731" map="01" />
+        </interleave>
+        <interleave output="16">
+            <part name="d14.u2" crc="c2cb1402" map="10" />
+            <part name="d16.u3" crc="50a1c63e" map="01" />
+        </interleave>
+        <!-- user1 - starts at 0x200000 -->
+        <part name="d15.u4" crc="6352cec0"/>
+        <part name="d17.u5" crc="7af810d8"/>
+        <!-- audiocpu - starts at 0x300000 -->
+        <part name="d19.u3" crc="47598459"/>
+        <!-- sprites0 - starts at 0x340000 -->
+        <part name="g02.u61" crc="91e30398"/>
+        <part name="g02.u62" crc="d9455dd7"/>
+        <part name="g02.u63" crc="4d20560b"/>
+        <part name="g02.u64" crc="b17b9b6e"/>
+        <part name="g02.u65" crc="08541878"/>
+        <part name="g02.u66" crc="becf2a36"/>
+        <part name="atgs.u1" crc="aa6f34a9"/>
+        <part name="atgs.u2" crc="553eda27"/>
+        <!-- layer0 - starts at 0x1340000 -->
+        <part name="atgs.u78" crc="16710ecb"/>
+        <!-- layer1 - starts at 0x1540000 -->
+        <part name="atgs.u81" crc="cb2aca91"/>
+        <!-- layer2 - starts at 0x1740000 -->
+        <part name="atgs.u89" crc="65f45a0f"/>
+        <!-- layer3 - starts at 0x1940000 -->
+        <part name="text.u82" crc="f57333ea"/>
+        <!-- oki1 - starts at 0x19C0000 -->
+        <part name="g02.u53" crc="c4bdd9e0"/>
+        <part name="g02.u54" crc="1357d50e"/>
+        <!-- oki2 - starts at 0x1DC0000 -->
+        <part name="g02.u55" crc="2d102898"/>
+        <part name="g02.u56" crc="9ff50dda"/>
+        <!-- Total 0x21C0000 bytes - 34560 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Guwange/Guwange (Japan, Special Ver. 00-07-07).mra
+++ b/mra/mame229/_Alternatives/_Guwange/Guwange (Japan, Special Ver. 00-07-07).mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+    <name>Guwange (Japan, Special Ver. 00/07/07)</name>
+    <setname>guwanges</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1999</year>
+    <manufacturer>Cave (Atlus license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="guwanges.zip|guwange.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="gu-u0127b.bin" crc="64667d2e" map="10" />
+            <part name="gu-u0129b.bin" crc="a99c6b6c" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="u083.bin" crc="adc4b9c4"/>
+        <part name="u082.bin" crc="3d75876c"/>
+        <part name="u086.bin" crc="188e4f81"/>
+        <part name="u085.bin" crc="a7d5659e"/>
+        <!-- layer0 - starts at 0x1900000 -->
+        <part name="u101.bin" crc="0369491f"/>
+        <!-- layer1 - starts at 0x2100000 -->
+        <part name="u10102.bin" crc="e28d6855"/>
+        <!-- layer2 - starts at 0x2500000 -->
+        <part name="u10103.bin" crc="0fe91b8e"/>
+        <!-- ymz - starts at 0x2900000 -->
+        <part name="u0462.bin" crc="b3d75691"/>
+        <!-- plds - starts at 0x2D00000 -->
+        <part name="atc05-1.bin" crc=""/>
+        <part name="u0259.bin" crc=""/>
+        <part name="u108.bin" crc=""/>
+        <part name="u084.bin" crc=""/>
+        <!-- eeprom - starts at 0x2D00004 -->
+        <part name="eeprom-guwange.bin" crc="c3174959"/>
+        <!-- Total 0x2D00084 bytes - 46080 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>5</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Mazinger Z/Mazinger Z (World).mra
+++ b/mra/mame229/_Alternatives/_Mazinger Z/Mazinger Z (World).mra
@@ -1,0 +1,39 @@
+<misterromdescription>
+    <name>Mazinger Z (World)</name>
+    <setname>mazinger</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1994</year>
+    <manufacturer>Banpresto / Dynamic Pl. Toei Animation</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>vertical</rotation>
+    <region>World</region>
+    <rom index="0" zip="mazinger.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="mzp-0.u24" crc="43a4279f" map="10" />
+        </interleave>
+        <!-- user1 - starts at 0x80000 -->
+        <part name="mzp-1.924" crc="db40acba"/>
+        <!-- audiocpu - starts at 0x100000 -->
+        <part name="mzs.u21" crc="c5b4f7ed"/>
+        <!-- sprites0 - starts at 0x120000 -->
+        <part name="bp943a-2.u56" crc="97e13959"/>
+        <part name="bp943a-3.u55" crc="9c4957dd"/>
+        <!-- layer0 - starts at 0x3A0000 -->
+        <part name="bp943a-1.u60" crc="46327415"/>
+        <!-- layer1 - starts at 0x5A0000 -->
+        <part name="bp943a-0.u63" crc="c1fed98a"/>
+        <!-- oki1 - starts at 0x7A0000 -->
+        <part name="bp943a-4.u64" crc="3fc7f29a"/>
+        <!-- eeprom - starts at 0x820000 -->
+        <part name="mazinger_world.nv" crc="4f6225c6"/>
+        <!-- Total 0x820080 bytes - 8320 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Metamoqester/Metamoqester (International).mra
+++ b/mra/mame229/_Alternatives/_Metamoqester/Metamoqester (International).mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+    <name>Metamoqester (International)</name>
+    <setname>metmqstr</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Banpresto / Pandorabox</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>World</region>
+    <rom index="0" zip="metmqstr.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bp947a.u25" crc="0a5c3442" map="10" />
+            <part name="bp947a.u28" crc="8c55decf" map="01" />
+        </interleave>
+        <interleave output="16">
+            <part name="bp947a.u29" crc="cf0f3f3b" map="10" />
+        </interleave>
+        <!-- audiocpu - starts at 0x180000 -->
+        <part name="bp947a.u20" crc="a4a36170"/>
+        <!-- sprites0 - starts at 0x1C0000 -->
+        <part name="bp947a.u49" crc="09749531"/>
+        <part name="bp947a.u50" crc="19cea8b2"/>
+        <part name="bp947a.u51" crc="c19bed67"/>
+        <part name="bp947a.u52" crc="70c64875"/>
+        <!-- layer0 - starts at 0x9C0000 -->
+        <part name="bp947a.u48" crc="04ff6a3d"/>
+        <!-- layer1 - starts at 0xBC0000 -->
+        <part name="bp947a.u47" crc="0de42827"/>
+        <!-- layer2 - starts at 0xDC0000 -->
+        <part name="bp947a.u46" crc="0f9c906e"/>
+        <!-- oki1 - starts at 0xFC0000 -->
+        <part name="bp947a.u42" crc="2ce8ff2a"/>
+        <!-- oki2 - starts at 0x11C0000 -->
+        <part name="bp947a.u37" crc="c3077c8f"/>
+        <!-- Total 0x13C0000 bytes - 20224 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Power Instinct 2/Power Instinct 2 (US, Ver. 94-04-08).mra
+++ b/mra/mame229/_Alternatives/_Power Instinct 2/Power Instinct 2 (US, Ver. 94-04-08).mra
@@ -1,0 +1,53 @@
+<misterromdescription>
+    <name>Power Instinct 2 (US, Ver. 94/04/08)</name>
+    <setname>pwrinst2</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1994</year>
+    <manufacturer>Atlus</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>World</region>
+    <rom index="0" zip="pwrinst2.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="g02.u45" crc="7b33bc43" map="10" />
+            <part name="g02.u44" crc="8f6f6637" map="01" />
+        </interleave>
+        <interleave output="16">
+            <part name="g02.u43" crc="178e3d24" map="10" />
+            <part name="g02.u42" crc="a0b4ee99" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x200000 -->
+        <part name="g02.u3a" crc="ebea5e1e"/>
+        <!-- sprites0 - starts at 0x220000 -->
+        <part name="g02.u61" crc="91e30398"/>
+        <part name="g02.u62" crc="d9455dd7"/>
+        <part name="g02.u63" crc="4d20560b"/>
+        <part name="g02.u64" crc="b17b9b6e"/>
+        <part name="g02.u65" crc="08541878"/>
+        <part name="g02.u66" crc="becf2a36"/>
+        <part name="g02.u67" crc="52fe2b8b"/>
+        <!-- layer0 - starts at 0x1020000 -->
+        <part name="g02.u78" crc="1eca63d2"/>
+        <!-- layer1 - starts at 0x1220000 -->
+        <part name="g02.u81" crc="8a3ff685"/>
+        <!-- layer2 - starts at 0x1320000 -->
+        <part name="g02.u89" crc="373e1f73"/>
+        <!-- layer3 - starts at 0x1420000 -->
+        <part name="g02.82a" crc="4b3567d6"/>
+        <!-- oki1 - starts at 0x14A0000 -->
+        <part name="g02.u53" crc="c4bdd9e0"/>
+        <part name="g02.u54" crc="1357d50e"/>
+        <!-- oki2 - starts at 0x18A0000 -->
+        <part name="g02.u55" crc="2d102898"/>
+        <part name="g02.u56" crc="9ff50dda"/>
+        <!-- Total 0x1CA0000 bytes - 29312 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,B4,Start,Coin,Pause" default="A,B,X,Y,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Europe).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Europe).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/21, Europe)</name>
+    <setname>sailormno</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Europe</region>
+    <rom index="0" zip="sailormno.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="97837ab4" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_europe.nv" crc="59a7dc50"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Hong Kong).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Hong Kong).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/21, Hong Kong)</name>
+    <setname>sailormnoh</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>World</region>
+    <rom index="0" zip="sailormnoh.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="97837ab4" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_hongkong.nv" crc="4d24c874"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Japan).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Japan).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/21, Japan)</name>
+    <setname>sailormnoj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="sailormnoj.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="97837ab4" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_japan.nv" crc="ea03c30a"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Korea).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Korea).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/21, Korea)</name>
+    <setname>sailormnok</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Korea</region>
+    <rom index="0" zip="sailormnok.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="97837ab4" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_korea.nv" crc="0e7de398"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Taiwan).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, Taiwan).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/21, Taiwan)</name>
+    <setname>sailormnot</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Taiwan</region>
+    <rom index="0" zip="sailormnot.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="97837ab4" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_taiwan.nv" crc="6c7e8c2a"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, USA).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-21, USA).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/21, USA)</name>
+    <setname>sailormnou</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>USA</region>
+    <rom index="0" zip="sailormnou.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="97837ab4" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_usa.nv" crc="3915abe3"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Europe).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Europe).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22, Europe)</name>
+    <setname>sailormnn</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Europe</region>
+    <rom index="0" zip="sailormnn.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="234f1152" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_europe.nv" crc="59a7dc50"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Hong Kong).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Hong Kong).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22, Hong Kong)</name>
+    <setname>sailormnnh</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>World</region>
+    <rom index="0" zip="sailormnnh.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="234f1152" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_hongkong.nv" crc="4d24c874"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Japan).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Japan).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22, Japan)</name>
+    <setname>sailormnnj</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Japan</region>
+    <rom index="0" zip="sailormnnj.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="234f1152" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_japan.nv" crc="ea03c30a"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Korea).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Korea).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22, Korea)</name>
+    <setname>sailormnnk</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Korea</region>
+    <rom index="0" zip="sailormnnk.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="234f1152" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_korea.nv" crc="0e7de398"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Taiwan).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, Taiwan).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22, Taiwan)</name>
+    <setname>sailormnnt</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Taiwan</region>
+    <rom index="0" zip="sailormnnt.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="234f1152" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_taiwan.nv" crc="6c7e8c2a"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, USA).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22, USA).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22, USA)</name>
+    <setname>sailormnnu</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>USA</region>
+    <rom index="0" zip="sailormnnu.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="smprg.u45" crc="234f1152" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_usa.nv" crc="3915abe3"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Europe).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Europe).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22B, Europe)</name>
+    <setname>sailormn</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Europe</region>
+    <rom index="0" zip="sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bpsm945a.u45" crc="898c9515" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_europe.nv" crc="59a7dc50"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Hong Kong).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Hong Kong).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22B, Hong Kong)</name>
+    <setname>sailormnh</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>World</region>
+    <rom index="0" zip="sailormnh.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bpsm945a.u45" crc="898c9515" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_hongkong.nv" crc="4d24c874"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Korea).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Korea).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22B, Korea)</name>
+    <setname>sailormnk</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Korea</region>
+    <rom index="0" zip="sailormnk.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bpsm945a.u45" crc="898c9515" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_korea.nv" crc="0e7de398"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Taiwan).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, Taiwan).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22B, Taiwan)</name>
+    <setname>sailormnt</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>Taiwan</region>
+    <rom index="0" zip="sailormnt.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bpsm945a.u45" crc="898c9515" map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_taiwan.nv" crc="6c7e8c2a"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, USA).mra
+++ b/mra/mame229/_Alternatives/_Pretty Soldier Sailor Moon/Pretty Soldier Sailor Moon (Ver. 95-03-22B, USA).mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+    <name>Pretty Soldier Sailor Moon (Ver. 95/03/22B, USA)</name>
+    <setname>sailormnu</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1995</year>
+    <manufacturer>Gazelle (Banpresto license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>USA</region>
+    <rom index="0" zip="sailormnu.zip|sailormn.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="bpsm945a.u45" crc="898c9515 map="10" />
+            <part name="bpsm.u46" crc="32084e80" map="01" />
+        </interleave>
+        <!-- audiocpu - starts at 0x280000 -->
+        <part name="bpsm945a.u9" crc="438de548"/>
+        <!-- sprites0 - starts at 0x300000 -->
+        <part name="bpsm.u76" crc="a243a5ba"/>
+        <part name="bpsm.u77" crc="5179a4ac"/>
+        <!-- layer0 - starts at 0x700000 -->
+        <part name="bpsm.u53" crc="b9b15f83"/>
+        <!-- layer1 - starts at 0x900000 -->
+        <part name="bpsm.u54" crc="8f00679d"/>
+        <!-- layer2 - starts at 0xB00000 -->
+        <part name="bpsm.u57" crc="86be7b63"/>
+        <part name="bpsm.u58" crc="e0bba83b"/>
+        <part name="bpsm.u62" crc="a1e3bfac"/>
+        <part name="bpsm.u61" crc="6a014b52"/>
+        <part name="bpsm.u60" crc="992468c0"/>
+        <part name="bpsm.u65" crc="f60fb7b5"/>
+        <part name="bpsm.u64" crc="6559d31c"/>
+        <part name="bpsm.u63" crc="d57a56b4"/>
+        <!-- oki1 - starts at 0x1B00000 -->
+        <part name="bpsm.u48" crc="498e4ed1"/>
+        <!-- oki2 - starts at 0x1D00000 -->
+        <part name="bpsm.u47" crc="0f2901b9"/>
+        <!-- eeprom - starts at 0x1D80000 -->
+        <part name="sailormn_usa.nv" crc="3915abe3"/>
+        <!-- Total 0x1D80080 bytes - 30208 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>00</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>

--- a/mra/mame229/_Alternatives/_Puzzle Uo Poko/Puzzle Uo Poko (International).mra
+++ b/mra/mame229/_Alternatives/_Puzzle Uo Poko/Puzzle Uo Poko (International).mra
@@ -1,0 +1,33 @@
+<misterromdescription>
+    <name>Puzzle Uo Poko (International)</name>
+    <setname>uopoko</setname>
+    <rbf>cave</rbf>
+    <mameversion>0229</mameversion>
+    <year>1998</year>
+    <manufacturer>Cave (Jaleco license)</manufacturer>
+    <players>2</players>
+    <joystick>8-way</joystick>
+    <rotation>horizontal</rotation>
+    <region>World</region>
+    <rom index="0" zip="uopoko.zip" type="merged" md5="None">
+        <!-- maincpu - starts at 0x0 -->
+        <interleave output="16">
+            <part name="u26.int" crc="b445c9ac" map="10" />
+            <part name="u25.int" crc="a1258482" map="01" />
+        </interleave>
+        <!-- sprites0 - starts at 0x100000 -->
+        <part name="cave_cv-02_u33.u33" crc="5d142ad2"/>
+        <!-- layer0 - starts at 0x500000 -->
+        <part name="cave_cv-02_u49.u49" crc="12fb11bb"/>
+        <!-- ymz - starts at 0x900000 -->
+        <part name="cave_cv-02_u4.u4" crc="a2d0d755"/>
+        <!-- eeprom - starts at 0xB00000 -->
+        <part name="eeprom-uopoko.bin" crc="f4a24b95"/>
+        <!-- Total 0xB00080 bytes - 11264 kBytes -->
+    </rom>
+    <!-- select game -->
+    <rom index="1">
+        <part>4</part>
+    </rom>
+    <buttons names="B1,B2,B3,Start,Coin,Pause" default="A,B,X,R,L,Start" />
+</misterromdescription>


### PR DESCRIPTION
The following MRA files were populated from the mame229 xml. This does not include any parent/child roms that require a special controller. The service button has not been mapped. Additional meta data to be added. This is an initial push to help you in testing @nullobject.

Additional sound hardware may need to be implemented.

Sound CPU : Z80 [Optional]
Sound Chips : YMZ280B or 1 or 2 OKIM6295 + YM2203 / YM2151 [Optional]

Per our discussion, I have added 0-5 for the corresponding roms.

```
0=Fever SOS / Dangun Feveron
1=DoDonPachi
2=DonPachi
3=ESP Ra.De.
4=Puzzle Uo Poko
5=Guwange
```

Interleave and mapping will need to be verified for the following MRA/Alternative files below as the main cpu count differ.

maincpu - starts at 0x0 (Count 1):
```
Akuu Gallet (Japan).mra
DonPachi (Japan).mra
Koro Koro Quest (Japan).mra
Mazinger Z (Japan).mra
_Air Gallet
_DonPachi
_Mazinger Z
```

maincpu - starts at 0x0 (Count 3):
```
Oni - The Ninja Master (Japan).mra
_Metamoqester
```

maincpu - starts at 0x0 (Count 4):
```
Gouketsuji Gaiden - Saikyou Densetsu (Japan, Ver. 95-06-20).mra
Gouketsuji Ichizoku 2 (Japan, Ver. 94-04-08).mra
_Gogetsuji Legends
_Power Instinct 2
```