### PR TITLE
Update DoDonPachi Trainer (Japan).mra

### DIFF
--- a/mra/DoDonPachi Trainer (Japan).mra
+++ b/mra/DoDonPachi Trainer (Japan).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
-  <name>DoDonPachi (Japan)</name>
+  <name>DoDonPachi Trainer (Japan)</name>
   <mameversion>0226</mameversion>
-  <setname>ddonpach</setname>
+  <setname></setname>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>


### PR DESCRIPTION
Remove the setname because it disturbs with arcade organizer. Also it is not in MAME