### PR TITLE
Update MRAs

### DIFF
--- a/mra/DoDonPachi Trainer (Japan).mra
+++ b/mra/DoDonPachi Trainer (Japan).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
-  <name>DoDonPachi (Japan)</name>
+  <name>DoDonPachi Trainer (Japan)</name>
   <mameversion>0226</mameversion>
-  <setname>ddonpach</setname>
+  <setname>ddonpachjt</setname>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>

--- a/releases/Dangun Feveron.mra
+++ b/releases/Dangun Feveron.mra
@@ -2,10 +2,10 @@
   <name>Dangun Feveron</name>
   <mameversion>0226</mameversion>
   <setname>dfeveron</setname>
-  <rotation>vertical (ccw)</rotation>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/Dangun Feveron.mra
+++ b/releases/Dangun Feveron.mra
@@ -2,6 +2,7 @@
   <name>Dangun Feveron</name>
   <mameversion>0226</mameversion>
   <setname>dfeveron</setname>
+  <rotation>vertical (ccw)</rotation>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>

--- a/releases/DoDonPachi (Arrange).mra
+++ b/releases/DoDonPachi (Arrange).mra
@@ -2,6 +2,7 @@
   <name>DoDonPachi (20120212 Arrange Ver. 1.1)</name>
   <mameversion>0226</mameversion>
   <setname>ddonpacha</setname>
+  <rotation>vertical (ccw)</rotation>
   <year>2012</year>
   <manufacturer>Hack (trap15)</manufacturer>
   <category>Shooter</category>

--- a/releases/DoDonPachi (Arrange).mra
+++ b/releases/DoDonPachi (Arrange).mra
@@ -2,10 +2,10 @@
   <name>DoDonPachi (20120212 Arrange Ver. 1.1)</name>
   <mameversion>0226</mameversion>
   <setname>ddonpacha</setname>
-  <rotation>vertical (ccw)</rotation>
   <year>2012</year>
   <manufacturer>Hack (trap15)</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/DoDonPachi (Japan).mra
+++ b/releases/DoDonPachi (Japan).mra
@@ -2,6 +2,7 @@
   <name>DoDonPachi (Japan)</name>
   <mameversion>0226</mameversion>
   <setname>ddonpachj</setname>
+  <rotation>vertical (ccw)</rotation>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>

--- a/releases/DoDonPachi (Japan).mra
+++ b/releases/DoDonPachi (Japan).mra
@@ -2,10 +2,10 @@
   <name>DoDonPachi (Japan)</name>
   <mameversion>0226</mameversion>
   <setname>ddonpachj</setname>
-  <rotation>vertical (ccw)</rotation>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/DoDonPachi Trainer (Japan).mra
+++ b/releases/DoDonPachi Trainer (Japan).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
   <name>DoDonPachi (Japan)</name>
   <mameversion>0226</mameversion>
-  <setname>ddonpach</setname>
+  <setname>ddonpachjt</setname>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>

--- a/releases/DoDonPachi Trainer (Japan).mra
+++ b/releases/DoDonPachi Trainer (Japan).mra
@@ -1,10 +1,11 @@
 <misterromdescription>
-  <name>DoDonPachi (Japan)</name>
+  <name>DoDonPachi Trainer (Japan)</name>
   <mameversion>0226</mameversion>
   <setname>ddonpachjt</setname>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/DoDonPachi.mra
+++ b/releases/DoDonPachi.mra
@@ -2,6 +2,7 @@
   <name>DoDonPachi</name>
   <mameversion>0226</mameversion>
   <setname>ddonpach</setname>
+  <rotation>vertical (ccw)</rotation>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>

--- a/releases/DoDonPachi.mra
+++ b/releases/DoDonPachi.mra
@@ -2,10 +2,10 @@
   <name>DoDonPachi</name>
   <mameversion>0226</mameversion>
   <setname>ddonpach</setname>
-  <rotation>vertical (ccw)</rotation>
   <year>1997</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/DonPachi (Japan).mra
+++ b/releases/DonPachi (Japan).mra
@@ -5,6 +5,7 @@
   <year>1995</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/DonPachi.mra
+++ b/releases/DonPachi.mra
@@ -5,6 +5,7 @@
   <year>1995</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/ESP Ra.De. (Japan).mra
+++ b/releases/ESP Ra.De. (Japan).mra
@@ -1,11 +1,11 @@
 <misterromdescription>
   <name>ESP Ra.De. (Japan)</name>
   <mameversion>0226</mameversion>
-  <rotation>vertical (ccw)</rotation>
   <setname>espradej</setname>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/ESP Ra.De. (Japan).mra
+++ b/releases/ESP Ra.De. (Japan).mra
@@ -1,6 +1,7 @@
 <misterromdescription>
   <name>ESP Ra.De. (Japan)</name>
   <mameversion>0226</mameversion>
+  <rotation>vertical (ccw)</rotation>
   <setname>espradej</setname>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>

--- a/releases/ESP Ra.De..mra
+++ b/releases/ESP Ra.De..mra
@@ -2,10 +2,10 @@
   <name>ESP Ra.De.</name>
   <mameversion>0226</mameversion>
   <setname>esprade</setname>
-  <rotation>vertical (ccw)</rotation>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/ESP Ra.De..mra
+++ b/releases/ESP Ra.De..mra
@@ -2,6 +2,7 @@
   <name>ESP Ra.De.</name>
   <mameversion>0226</mameversion>
   <setname>esprade</setname>
+  <rotation>vertical (ccw)</rotation>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>

--- a/releases/Fever SOS.mra
+++ b/releases/Fever SOS.mra
@@ -2,10 +2,10 @@
   <name>Fever SOS</name>
   <mameversion>0226</mameversion>
   <setname>feversos</setname>
-  <rotation>vertical (ccw)</rotation>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/Fever SOS.mra
+++ b/releases/Fever SOS.mra
@@ -2,6 +2,7 @@
   <name>Fever SOS</name>
   <mameversion>0226</mameversion>
   <setname>feversos</setname>
+  <rotation>vertical (ccw)</rotation>
   <year>1998</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>

--- a/releases/Guwange (Special).mra
+++ b/releases/Guwange (Special).mra
@@ -5,6 +5,7 @@
   <year>1999</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->

--- a/releases/Guwange.mra
+++ b/releases/Guwange.mra
@@ -5,6 +5,7 @@
   <year>1999</year>
   <manufacturer>CAVE</manufacturer>
   <category>Shooter</category>
+  <rotation>vertical (ccw)</rotation>
   <rbf>cave</rbf>
 
   <!-- ROM data -->


### PR DESCRIPTION
The dodonpachi trainer MRA had the same setname as "DoDonpachi.mra"
In this pull request, I have added a unique setname for this which will fix issues with arcade organizer. 

EDIT: I've added a rotation tag to the MRAs (according to MAME). Now users can use the [arcade_vertical] tag in mister.ini file to specify TATE arcade games